### PR TITLE
[chore]: bumped package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-tailwind",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The version number in package.json was incorrect. This PR corrects the version number from 1.0.0 to 0.0.1.